### PR TITLE
feat: add support for 1.21.1

### DIFF
--- a/src/main/java/com/bgsoftware/common/nmsloader/NMSHandlersFactory.java
+++ b/src/main/java/com/bgsoftware/common/nmsloader/NMSHandlersFactory.java
@@ -69,7 +69,7 @@ public class NMSHandlersFactory {
                     new NMSVersionRequirement(3699, null),
                     new NMSVersionRequirement(3700, "v1_20_3"),
                     new NMSVersionRequirement(3839, "v1_20_4"),
-                    new NMSVersionRequirement(3953, "v1_21")
+                    new NMSVersionRequirement(3955, "v1_21")
             );
 
             for (NMSVersionRequirement versionData : versions) {


### PR DESCRIPTION
This commit and PR changes the data version int to 3955, which is the required one for 1.21.1, and thus allows support for 1.21.1